### PR TITLE
Consider reek configuration when selecting files to lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Layout/AlignHash:

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'reek/plugin'

--- a/lib/danger_reek.rb
+++ b/lib/danger_reek.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'reek/gem_version'

--- a/lib/reek/gem_version.rb
+++ b/lib/reek/gem_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reek
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.1'
 end

--- a/lib/reek/plugin.rb
+++ b/lib/reek/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reek'
 require 'reek/cli/options'
 require 'reek/source/source_locator'

--- a/lib/reek/plugin.rb
+++ b/lib/reek/plugin.rb
@@ -19,24 +19,24 @@ module Danger
     # Runs Ruby files through Reek.
     # @return [Array<Reek::SmellWarning, nil>]
     def lint
-      files_to_lint = fetch_files_to_lint
-      code_smells   = run_linter(files_to_lint)
+      configuration = ::Reek::Configuration::AppConfiguration.from_path(nil)
+      files_to_lint = fetch_files_to_lint(configuration)
+      code_smells   = run_linter(files_to_lint, configuration)
       warn_each_line(code_smells)
     end
 
     private
 
-    def run_linter(files_to_lint)
-      configuration = ::Reek::Configuration::AppConfiguration.from_path(nil)
+    def run_linter(files_to_lint, configuration)
       files_to_lint.flat_map do |file|
         examiner = ::Reek::Examiner.new(file, configuration: configuration)
         examiner.smells
       end
     end
 
-    def fetch_files_to_lint
+    def fetch_files_to_lint(configuration)
       files = git.modified_files + git.added_files
-      ::Reek::Source::SourceLocator.new(files).sources
+      ::Reek::Source::SourceLocator.new(files, configuration: configuration).sources
     end
 
     def warn_each_line(code_smells)

--- a/spec/reek_spec.rb
+++ b/spec/reek_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('spec_helper', __dir__)
 
 module Danger

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 ROOT = Pathname.new(File.expand_path('..', __dir__))
 $:.unshift((ROOT + 'lib').to_s)


### PR DESCRIPTION
This makes it so the list of files to be linted respects the settings
on the reek configuration file (.reek.yml). Previosuly, the files
ignored there would still be linted