### PR TITLE
Add force_exclusion option when running reek

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,6 @@
 Style/ClassCheck:
   EnforcedStyle: kind_of?
 
-# It's better to be more explicit about the type
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # specs sometimes have useless assignments, which is fine
 Lint/UselessAssignment:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ reek.lint</pre>
 
 #### Methods
 
-`lint` - Runs Ruby files through Reek.
+`lint(config: Hash)` - Runs Ruby files through Reek.
+
+This method accepts a configuration hash.
+The following keys are supported:
+
+* `force_exclusion`: pass `true` to pass `--force-exclusion` argument to Reek.
+  (this option will instruct reek to ignore the files that your reek config ignores)
 
 ## Development
 

--- a/lib/reek/plugin.rb
+++ b/lib/reek/plugin.rb
@@ -17,6 +17,7 @@ module Danger
   # @tags ruby, reek, lint
   class DangerReek < Plugin
     # Runs Ruby files through Reek.
+    # @param   [Hash] config
     # @return [Array<Reek::SmellWarning, nil>]
     def lint(config = {})
       @force_exclusion = config[:force_exclusion] || false
@@ -28,13 +29,11 @@ module Danger
 
     private
 
-    attr_reader :configuration, :force_exclusion
-
     def run_linter(files_to_lint)
       files_to_lint.flat_map do |file|
         next if ignore_file?(file)
 
-        examiner = ::Reek::Examiner.new(file, configuration: configuration)
+        examiner = ::Reek::Examiner.new(file, configuration: @configuration)
         examiner.smells
       end.compact
     end
@@ -55,12 +54,12 @@ module Danger
     end
 
     def ignore_file?(file)
-      if force_exclusion
+      if @force_exclusion
         file.ascend.any? do |ascendant|
-          configuration.path_excluded?(ascendant)
+          @configuration.path_excluded?(ascendant)
         end
       else
-        configuration.path_excluded?(file)
+        @configuration.path_excluded?(file)
       end
     end
   end


### PR DESCRIPTION
## Why
- `exclude_paths` is not supported when running in Danger, the ignored files have still been run.
- Although Reek supported `--force_exclusion` param https://github.com/troessner/reek/pull/1200, we can not use it with `Reek::Examiner`. That why we need to handle it ourself

## Insights
- Add a config parameter hash when running the linter, and get `force_exclusion` from it
- Add a method to check whether not the files should be ignored
