### PR TITLE
Respect exclude_paths config

### DIFF
--- a/lib/reek/plugin.rb
+++ b/lib/reek/plugin.rb
@@ -27,7 +27,6 @@ module Danger
     private
 
     def run_linter(files_to_lint)
-      configuration = ::Reek::Configuration::AppConfiguration.from_path(nil)
       files_to_lint.flat_map do |file|
         examiner = ::Reek::Examiner.new(file, configuration: configuration)
         examiner.smells
@@ -36,7 +35,7 @@ module Danger
 
     def fetch_files_to_lint
       files = git.modified_files + git.added_files
-      ::Reek::Source::SourceLocator.new(files).sources
+      ::Reek::Source::SourceLocator.new(files, configuration: configuration).sources
     end
 
     def warn_each_line(code_smells)
@@ -47,6 +46,10 @@ module Danger
           warn(message, file: source, line: line)
         end
       end
+    end
+
+    def configuration
+      @configuration ||= ::Reek::Configuration::AppConfiguration.from_path(nil)
     end
   end
 end

--- a/spec/reek_spec.rb
+++ b/spec/reek_spec.rb
@@ -55,6 +55,26 @@ module Danger
             end
           end
 
+          context 'when changed files are in exclude_paths in reek configuration' do
+            let(:stubbings) { changed_files && configuration }
+
+            let(:configuration) do
+              allow(::Reek::Configuration::AppConfiguration)
+                .to receive(:from_path)
+                .and_return(
+                  ::Reek::Configuration::AppConfiguration.new(
+                    values: { 'exclude_paths' => [*modified_files, *added_files] }
+                  )
+                )
+
+              allow(::Reek::Examiner).to receive(:new).and_call_original
+            end
+
+            it 'does not examine files' do
+              expect(::Reek::Examiner).not_to have_received(:new).with(any_args)
+            end
+          end
+
           context 'with no code smells' do
             let(:stubbings) { changed_files }
 


### PR DESCRIPTION
## Description
 
- Currently, this plugin does not respect reek configuration `exclude_paths`. 
-  Adding configuration to `::Reek::Source::SourceLocator`.
